### PR TITLE
Added headers handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- headers when writing message
+- headers when reading message
+- `getMiaHeaders` function
+
 ## [1.0.4] 2022-10-26
 
 ### Changed

--- a/index.d.ts
+++ b/index.d.ts
@@ -92,3 +92,8 @@ export interface FlowManagerClient {
 
   emit(event: string, sagaId: string, metadata?: Record<string, any>, headers?: Record<string, any>): Promise<void>
 }
+
+//
+// Utility
+//
+export function getMiaHeaders(headers: Record<string, any>): Record<string, string>

--- a/index.d.ts
+++ b/index.d.ts
@@ -66,11 +66,11 @@ export class FMClientBuilder {
 //
 export type PayloadGeneric<T = Record<string, any>> = T
 
-export type EventEmitter = (event: string, metadata?: Record<string, any>) => Promise<void>
+export type EventEmitter = (event: string, metadata?: Record<string, any>, headers?: Record<string, any>) => Promise<void>
 
 export type Heartbeat = () => Promise<void>
 
-export type CommandExecutor<Payload extends PayloadGeneric = PayloadGeneric> = (sagaId: string, payload: Payload, eventEmitter: EventEmitter, heartbeat: Heartbeat) => void
+export type CommandExecutor<Payload extends PayloadGeneric = PayloadGeneric> = (sagaId: string, payload: Payload, eventEmitter: EventEmitter, heartbeat: Heartbeat, headers: Payload) => void
 
 export type CommitCallback = () => Promise<void>
 
@@ -90,5 +90,5 @@ export interface FlowManagerClient {
 
   onCommand<Payload extends PayloadGeneric = PayloadGeneric>(command: string, executor: CommandExecutor<Payload>, errorHandler?: CommandErrorHandler): void
 
-  emit(event: string, sagaId: string, metadata?: Record<string, any>): Promise<void>
+  emit(event: string, sagaId: string, metadata?: Record<string, any>, headers?: Record<string, any>): Promise<void>
 }

--- a/index.js
+++ b/index.js
@@ -17,5 +17,6 @@
 'use strict'
 
 const { FMClientBuilder, getMetrics } = require('./lib/builder')
+const { getMiaHeaders } = require('./lib/client')
 
-module.exports = { FMClientBuilder, getMetrics }
+module.exports = { FMClientBuilder, getMetrics, getMiaHeaders }

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -17,7 +17,7 @@
 'use strict'
 
 const Ajv = require('ajv')
-const FlowManagerClient = require('./client')
+const { FlowManagerClient } = require('./client')
 
 const ajv = new Ajv({ coerceTypes: true, useDefaults: true })
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -343,14 +343,17 @@ function commaStringToList(str) {
   return str.split(',').filter(elem => elem && elem.trim().length > 0)
 }
 
-function getMiaHeaders(receivedHeaders) {
+function getMiaHeaders(headers) {
   return omitBy({
-    'miauserid': receivedHeaders.miauserid,
-    'miausergroups': receivedHeaders.miausergroups,
-    'client-type': receivedHeaders['client-type'],
-    'isbackoffice': receivedHeaders.isbackoffice,
-    'microservice-gateway': receivedHeaders['microservice-gateway'],
+    'miauserid': headers.miauserid,
+    'miausergroups': headers.miausergroups,
+    'client-type': headers['client-type'],
+    'isbackoffice': headers.isbackoffice,
+    'microservice-gateway': headers['microservice-gateway'],
   }, isUndefined)
 }
 
-module.exports = FlowManagerClient
+module.exports = {
+  FlowManagerClient,
+  getMiaHeaders,
+}

--- a/lib/client.js
+++ b/lib/client.js
@@ -19,6 +19,8 @@
 
 const { Kafka, logLevel } = require('kafkajs')
 const PinoLogCreator = require('@mia-platform/kafkajs-pino-logger')
+const omitBy = require('lodash.omitby')
+const isUndefined = require('lodash.isundefined')
 
 const CAN_AUTOCREATE_TOPICS = false
 const JOIN_WAIT_TIME = 100
@@ -240,7 +242,18 @@ function createCommandsDispatcher(fmClient) {
 
     try {
       // eslint-disable-next-line no-shadow
-      const eventEmitter = (event, metadata, headers) => fmClient.emit(event, sagaId, metadata, headers)
+      const eventEmitter = (event, metadata, headers = {}, options = {}) => {
+        let emittedHeaders
+        if (options.isMiaHeaderInjected === false) {
+          emittedHeaders = headers
+        } else {
+          emittedHeaders = {
+            ...getMiaHeaders(parsedHeaders),
+            ...headers,
+          }
+        }
+        fmClient.emit(event, sagaId, metadata, emittedHeaders)
+      }
 
       const commandFunction = commandsMap.get(command)
       // handle commands not expected
@@ -328,6 +341,16 @@ function prepareConfig({
 
 function commaStringToList(str) {
   return str.split(',').filter(elem => elem && elem.trim().length > 0)
+}
+
+function getMiaHeaders(receivedHeaders) {
+  return omitBy({
+    'miauserid': receivedHeaders.miauserid,
+    'miausergroups': receivedHeaders.miausergroups,
+    'client-type': receivedHeaders['client-type'],
+    'isbackoffice': receivedHeaders.isbackoffice,
+    'microservice-gateway': receivedHeaders['microservice-gateway'],
+  }, isUndefined)
 }
 
 module.exports = FlowManagerClient

--- a/lib/client.js
+++ b/lib/client.js
@@ -346,10 +346,15 @@ function commaStringToList(str) {
 function getMiaHeaders(headers) {
   return omitBy({
     'miauserid': headers.miauserid,
+    'miauserproperties': headers.miauserproperties,
     'miausergroups': headers.miausergroups,
     'client-type': headers['client-type'],
     'isbackoffice': headers.isbackoffice,
     'microservice-gateway': headers['microservice-gateway'],
+    'x-request-id': headers['x-request-id'],
+    'x-forwarded-for': headers['x-forwarded-for'],
+    'x-forwarded-proto': headers['x-forwarded-proto'],
+    'x-forwarded-host': headers['x-forwarded-host'],
   }, isUndefined)
 }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -177,7 +177,7 @@ class FlowManagerClient {
     }
   }
 
-  async emit(event, sagaId, metadata = {}) {
+  async emit(event, sagaId, metadata = {}, headers = {}) {
     if (!this.producer) {
       throw new Error('events emitter component not configured')
     }
@@ -191,6 +191,7 @@ class FlowManagerClient {
               messageLabel: event,
               messagePayload: metadata,
             }),
+            headers,
           },
         ],
       })
@@ -208,7 +209,7 @@ function createCommandsDispatcher(fmClient) {
 
   // eslint-disable-next-line max-statements
   return async({ topic, message, partition, heartbeat }) => {
-    const { key, value, offset } = message
+    const { key, value, offset, headers } = message
 
     const sagaId = key?.toString()
     if (!sagaId) {
@@ -232,8 +233,14 @@ function createCommandsDispatcher(fmClient) {
       return
     }
 
+    const parsedHeaders = {}
+    for (const [headerKey, headerValue] of Object.entries(headers)) {
+      parsedHeaders[headerKey] = headerValue.toString()
+    }
+
     try {
-      const eventEmitter = (event, metadata) => fmClient.emit(event, sagaId, metadata)
+      // eslint-disable-next-line no-shadow
+      const eventEmitter = (event, metadata, headers) => fmClient.emit(event, sagaId, metadata, headers)
 
       const commandFunction = commandsMap.get(command)
       // handle commands not expected
@@ -243,7 +250,7 @@ function createCommandsDispatcher(fmClient) {
         return
       }
 
-      await commandFunction(sagaId, payload, eventEmitter, heartbeat)
+      await commandFunction(sagaId, payload, eventEmitter, heartbeat, parsedHeaders)
     } catch (executorError) {
       sagaLogger.error(
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1974,11 +1974,21 @@
       "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
+    "lodash.isundefined": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
+      "integrity": "sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA=="
+    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "lodash.omitby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.omitby/-/lodash.omitby-4.6.0.tgz",
+      "integrity": "sha512-5OrRcIVR75M288p4nbI2WLAf3ndw2GD9fyNv3Bc15+WCxJDdZ4lYndSxGd7hnG6PVjiJTeJE2dHEGhIuKGicIQ=="
     },
     "log-symbols": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
   "dependencies": {
     "@mia-platform/kafkajs-pino-logger": "^1.0.0",
     "ajv": "^8.11.0",
-    "kafkajs": "^1.16.0"
+    "kafkajs": "^1.16.0",
+    "lodash.isundefined": "^3.0.1",
+    "lodash.omitby": "^4.6.0"
   },
   "devDependencies": {
     "@mia-platform/eslint-config-mia": "^3.0.0",

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -26,7 +26,7 @@ const { sleep, assertMessages } = kafkaCommon
 
 const getConfig = require('./getConfig')
 
-const FlowManagerClient = require('../lib/client')
+const { FlowManagerClient } = require('../lib/client')
 
 tap.test('Flow Manager Client', async t => {
   const conf = getConfig()

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -243,6 +243,7 @@ tap.test('Flow Manager Client', async t => {
           messageLabel: event,
           messagePayload: metadata,
         },
+        headers: {},
       },
     ]
 
@@ -301,6 +302,7 @@ tap.test('Flow Manager Client', async t => {
           messageLabel: event,
           messagePayload: payload,
         },
+        headers: {},
       },
     ]
 
@@ -311,6 +313,187 @@ tap.test('Flow Manager Client', async t => {
     } = await kafkaCommon.messagesReceiver(kafkaInstance, topicsMap.evn, eventMessage.length)
 
     const fakeExecutor = async(sagaId, metadata, testEmitter) => { await testEmitter(event, metadata) }
+    const fakeMetrics = {
+      commandsExecuted: { inc: sinon.fake() },
+      eventsEmitted: { inc: sinon.fake() },
+    }
+
+    const log = pino({ level: conf.LOG_LEVEL || 'silent' })
+    const client = new FlowManagerClient(
+      log,
+      {
+        kafkaConf,
+        components: {
+          commandsExecutor: {
+            consumerConf,
+            commandsTopic: topicsMap.cmd,
+          },
+          eventsEmitter: {
+            producerConf: {},
+            eventsTopic: topicsMap.evn,
+          },
+        },
+      },
+      fakeMetrics,
+    )
+    assert.teardown(async() => {
+      await stopTestConsumer()
+      await commandIssuer.disconnect()
+    })
+
+    client.onCommand(command, fakeExecutor)
+
+    await client.start()
+
+    await commandIssuer.send({ topic: topicsMap.cmd, messages: [commandMessage] })
+
+    await waitForReception
+    assertMessages(assert, messagesReceived, eventMessage)
+
+    // wait for reception
+    await client.stop()
+
+    assert.equal(fakeMetrics.commandsExecuted.inc.callCount, 1, 'only subscribed commands are executed')
+    assert.equal(fakeMetrics.eventsEmitted.inc.callCount, 1)
+
+    assert.end()
+  })
+
+  t.test('execute command and emit event forwarding Mia and custom headers', async assert => {
+    const commandIssuer = await kafkaCommon.createProducer(kafkaInstance)
+
+    const command = 'performAction'
+    const sagaId = 'd7cddc1b-393d-4827-a2ae-ae8d311c2372'
+    const payload = { msg: 'new command and event' }
+    const event = 'eventAfterCommand'
+    const miaHeaders = {
+      miauserid: 'userid',
+      isbackoffice: 'is-backoffice',
+    }
+    const customHeaders = {
+      newHeader: 'value',
+    }
+
+    const commandMessage = {
+      key: sagaId,
+      value: JSON.stringify({
+        messageLabel: command,
+        messagePayload: payload,
+      }),
+      headers: miaHeaders,
+    }
+    const eventMessage = [
+      {
+        key: sagaId,
+        value: {
+          messageLabel: event,
+          messagePayload: payload,
+        },
+        headers: {
+          ...miaHeaders,
+          ...customHeaders,
+        },
+      },
+    ]
+
+    const {
+      waitForReception,
+      messagesReceived,
+      stopTestConsumer,
+    } = await kafkaCommon.messagesReceiver(kafkaInstance, topicsMap.evn, eventMessage.length)
+
+    const fakeExecutor = async(sagaId, metadata, testEmitter) => {
+      await testEmitter(event, metadata, customHeaders)
+    }
+    const fakeMetrics = {
+      commandsExecuted: { inc: sinon.fake() },
+      eventsEmitted: { inc: sinon.fake() },
+    }
+
+    const log = pino({ level: conf.LOG_LEVEL || 'silent' })
+    const client = new FlowManagerClient(
+      log,
+      {
+        kafkaConf,
+        components: {
+          commandsExecutor: {
+            consumerConf,
+            commandsTopic: topicsMap.cmd,
+          },
+          eventsEmitter: {
+            producerConf: {},
+            eventsTopic: topicsMap.evn,
+          },
+        },
+      },
+      fakeMetrics,
+    )
+    assert.teardown(async() => {
+      await stopTestConsumer()
+      await commandIssuer.disconnect()
+    })
+
+    client.onCommand(command, fakeExecutor)
+
+    await client.start()
+
+    await commandIssuer.send({ topic: topicsMap.cmd, messages: [commandMessage] })
+
+    await waitForReception
+    assertMessages(assert, messagesReceived, eventMessage)
+
+    // wait for reception
+    await client.stop()
+
+    assert.equal(fakeMetrics.commandsExecuted.inc.callCount, 1, 'only subscribed commands are executed')
+    assert.equal(fakeMetrics.eventsEmitted.inc.callCount, 1)
+
+    assert.end()
+  })
+
+  t.test('execute command and emit event forwarding custom headers', async assert => {
+    const commandIssuer = await kafkaCommon.createProducer(kafkaInstance)
+
+    const command = 'performAction'
+    const sagaId = 'd7cddc1b-393d-4827-a2ae-ae8d311c2372'
+    const payload = { msg: 'new command and event' }
+    const event = 'eventAfterCommand'
+    const miaHeaders = {
+      miauserid: 'userid',
+      isbackoffice: 'is-backoffice',
+    }
+    const customHeaders = {
+      newHeader: 'value',
+    }
+
+    const commandMessage = {
+      key: sagaId,
+      value: JSON.stringify({
+        messageLabel: command,
+        messagePayload: payload,
+      }),
+      headers: miaHeaders,
+    }
+    const eventMessage = [
+      {
+        key: sagaId,
+        value: {
+          messageLabel: event,
+          messagePayload: payload,
+        },
+        headers: customHeaders,
+      },
+    ]
+
+    const {
+      waitForReception,
+      messagesReceived,
+      stopTestConsumer,
+    } = await kafkaCommon.messagesReceiver(kafkaInstance, topicsMap.evn, eventMessage.length)
+
+    const fakeExecutor = async(sagaId, metadata, testEmitter) => {
+      await testEmitter(event, metadata, customHeaders, { isMiaHeaderInjected: false })
+    }
     const fakeMetrics = {
       commandsExecuted: { inc: sinon.fake() },
       eventsEmitted: { inc: sinon.fake() },

--- a/tests/kafkaTestsHelpers.js
+++ b/tests/kafkaTestsHelpers.js
@@ -117,8 +117,13 @@ async function runConsumer({ consumer, messagesReceived, expectedMsgCount, minMs
     eachMessage: async({ message }) => {
       const key = message.key.toString()
       const value = JSON.parse(message.value.toString())
+      const { headers } = message
+      const parsedHeaders = {}
+      for (const [headerKey, headerValue] of Object.entries(headers)) {
+        parsedHeaders[headerKey] = headerValue.toString()
+      }
 
-      messagesReceived.push({ key, value })
+      messagesReceived.push({ key, value, headers: parsedHeaders })
       if (messagesReceived.length >= expectedMsgCount) {
         confirmReception()
       }


### PR DESCRIPTION
Headers of kafka messages can now be read (command case) and written (emit event case).

Using the emitEvent of commandExecutor, Mia headers are forwarded by default. This feature can be disabled with an option.

#### Checklist

- [x] your branch will not cause merge conflict with `master`
- [x] run `npm test`
- [x] tests are included
- [x] the documentation is updated or integrated accordingly with your changes
- [x] the code will follow the lint rules and style of the project
- [x] you are not committing extraneous files or sensible data
