### PR TITLE
Added partition-aware concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- added the property `partitionsConsumedConcurrently` to the command executor
+
 ## [1.0.4] 2022-10-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ kafkaConfig = {
   username: { type: 'string', nullable: true },
   password: { type: 'string', nullable: true },
   connectionTimeout: { type: 'integer', default: 10000, description: 'milliseconds' },
-  authenticationTimeout: { type: 'integer', default: 10000, description: 'milliseconds' }
+  authenticationTimeout: { type: 'integer', default: 10000, description: 'milliseconds' },
   connectionRetries: { type: 'integer', default: 5, description: 'number of times the client should try to connect'}
 }
 
@@ -97,7 +97,7 @@ Example:
 const { FMClientBuilder } = require('@mia-platform/flow-manager-client')
 
 const client = new FMClientBuilder(pinoLogger, kafkaConfig)
-  .configureCommandsExecutor(commandsTopic, consumerConf)
+  .configureCommandsExecutor(commandsTopic, consumerConf, partitionsConsumedConcurrently)
   .configureEventsEmitter(eventsTopic, producerConf)
   .build()
 
@@ -157,6 +157,8 @@ execution is successful. This behaviour can be fine in case the command action i
   In order to change it and *skip messages* whose processing throw an error,
   it is sufficient to call the `commit` function within the error handler.
   That function is provided as a parameter to the error handler, in conjunction with the processing error.
+- by default commands are read sequentially but, if you have multiple partitions assigned to the same client, you can set the partitionsConsumedConcurrently property of the commandExecutor to parallelize the execution of the commands in different partitions. This can improve performances if the command consists of asynchronous work. For reference: [Partition-aware concurrency](https://kafka.js.org/docs/consuming#partition-aware-concurrency)
+
 
 #### `async emit(event, sagaId, metadata)`
 _emit_ allows to publish a new message in the _events_ topic. It can throw in case sending a message results in a failure.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -43,7 +43,7 @@ Example:
 const { FMClientBuilder } = require('@mia-platform/flow-manager-client')
 
 const client = new FMClientBuilder(pinoLogger, kafkaConfig)
-  .configureCommandsExecutor(commandsTopic, consumerConf)
+  .configureCommandsExecutor(commandsTopic, consumerConf, partitionsConsumedConcurrently)
   .configureEventsEmitter(eventsTopic, producerConf)
   .build()
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -10,18 +10,18 @@ npm i --save @mia-platform/flow-manager-client
 
 #### Create a network connection
 
-```
+```shell
 docker network create app --driver bridge
 ```
 
 #### Pull the images
-```
+```shell
 docker pull bitnami/zookeeper
 docker pull bitnami/kafka
 ```
 
 #### Run the images
-```
+```shell
 docker run -d --rm --name zookeeper --network=app -e ALLOW_ANONYMOUS_LOGIN=yes -p 2180:2181 bitnami/zookeeper
 
 docker run --rm \
@@ -42,6 +42,12 @@ docker run --rm \
 
 #### Run tests
 
-```
+```shell
 npm test
+```
+
+#### Clear docker
+```shell
+docker kill zookeeper
+docker network rm app
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -52,7 +52,11 @@ export class FMClientBuilder {
 
   constructor(log: Record<string, any>, kafkaConfig: KafkaConfig)
 
-  configureCommandsExecutor(commandsTopic: string, consumerConfig: ConsumerConfig): FMClientBuilder
+  configureCommandsExecutor(
+      commandsTopic: string,
+      consumerConfig: ConsumerConfig,
+      partitionsConsumedConcurrently?: number
+  ): FMClientBuilder
 
   configureEventsEmitter(eventsTopic: string, producerConfig?: ProducerConfig): FMClientBuilder
 

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -64,6 +64,7 @@ const configSchema = {
               },
             },
             commandsTopic: { type: 'string' },
+            partitionsConsumedConcurrently: { type: 'integer', default: 1 },
           },
         },
         eventsEmitter: {
@@ -93,10 +94,11 @@ class FMClientBuilder {
     this.metrics = {}
   }
 
-  configureCommandsExecutor(commandsTopic, consumerConfig) {
+  configureCommandsExecutor(commandsTopic, consumerConfig, partitionsConsumedConcurrently = 1) {
     this.commandsExecutorConf = {
       consumerConf: consumerConfig,
       commandsTopic,
+      partitionsConsumedConcurrently,
     }
     return this
   }

--- a/lib/client.js
+++ b/lib/client.js
@@ -43,7 +43,7 @@ class FlowManagerClient {
   }
 
   _configureConsumer(kafka, conf) {
-    const { consumerConf, commandsTopic } = conf
+    const { consumerConf, commandsTopic, partitionsConsumedConcurrently } = conf
     this.consumer = kafka.consumer({
       allowAutoTopicCreation: CAN_AUTOCREATE_TOPICS,
       ...consumerConf,
@@ -76,6 +76,7 @@ class FlowManagerClient {
     ]
 
     this.commandsTopic = commandsTopic
+    this.partitionsConsumedConcurrently = partitionsConsumedConcurrently
     this.commandsMap = new Map()
     this.errorHandlersMap = new Map()
     // initial state is healthy to allow K8s service bootstrap
@@ -130,6 +131,7 @@ class FlowManagerClient {
 
     await this.consumer?.subscribe({ topic: this.commandsTopic })
     await this.consumer?.run({
+      partitionsConsumedConcurrently: this.partitionsConsumedConcurrently,
       autoCommit: false,
       eachMessage: createCommandsDispatcher(this),
     })

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "npm run lint && npm run unit && npm run checkonly && npm run typescript",
     "typescript": "tsd",
     "update-changelog": "node scripts/update-changelog.js ${npm_package_version}",
-    "unit": "tap -b tests/*.test.js tests/**/*.test.js -t 180",
+    "unit": "tap -b tests/*.test.js tests/**/*.test.js -t 120",
     "version": "npm run update-changelog && git add CHANGELOG.md"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "npm run lint && npm run unit && npm run checkonly && npm run typescript",
     "typescript": "tsd",
     "update-changelog": "node scripts/update-changelog.js ${npm_package_version}",
-    "unit": "tap -b tests/*.test.js tests/**/*.test.js -t 120",
+    "unit": "tap -b tests/*.test.js tests/**/*.test.js -t 180",
     "version": "npm run update-changelog && git add CHANGELOG.md"
   },
   "dependencies": {

--- a/tests/builder.test.js
+++ b/tests/builder.test.js
@@ -39,7 +39,7 @@ tap.test('Flow Manager Client Builder', async t => {
   t.test('initialize a client with both components', async assert => {
     const log = pino({ level: conf.LOG_LEVEL || 'silent' })
     const client = new FMClientBuilder(log, kafkaConf)
-      .configureCommandsExecutor(conf.KAFKA_CMD_TOPIC, consumerConf)
+      .configureCommandsExecutor(conf.KAFKA_CMD_TOPIC, consumerConf, 3)
       .configureEventsEmitter(conf.KAFKA_EVN_TOPIC, producerConf)
       .build()
     assert.teardown(async() => {

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -242,6 +242,30 @@ tap.test('Flow Manager Client', async t => {
       await commandIssuer.disconnect()
     })
 
+    const command1 = 'command1'
+    const sagaId1 = 'sagaId1'
+    const command2 = 'command2'
+    const sagaId2 = 'sagaId2'
+    const payload = { msg: 'a new command has been issued' }
+
+    const messages = [
+      {
+        key: sagaId1,
+        value: JSON.stringify({
+          messageLabel: command1,
+          messagePayload: payload,
+        }),
+        partition: 0,
+      }, {
+        key: sagaId2,
+        value: JSON.stringify({
+          messageLabel: command2,
+          messagePayload: payload,
+        }),
+        partition: 1,
+      },
+    ]
+
     t.test('execute commands in 2 partition sequentially if partitionsConsumedConcurrently is 1', async assert => {
       const client = new FlowManagerClient(
         log,
@@ -261,30 +285,6 @@ tap.test('Flow Manager Client', async t => {
       assert.teardown(async() => {
         await client.stop()
       })
-
-      const command1 = 'command1'
-      const sagaId1 = 'sagaId1'
-      const command2 = 'command2'
-      const sagaId2 = 'sagaId2'
-      const payload = { msg: 'a new command has been issued' }
-
-      const messages = [
-        {
-          key: sagaId1,
-          value: JSON.stringify({
-            messageLabel: command1,
-            messagePayload: payload,
-          }),
-          partition: 0,
-        }, {
-          key: sagaId2,
-          value: JSON.stringify({
-            messageLabel: command2,
-            messagePayload: payload,
-          }),
-          partition: 1,
-        },
-      ]
 
       let start1, end1, start2, end2
       const executor1 = async() => {
@@ -340,30 +340,6 @@ tap.test('Flow Manager Client', async t => {
       assert.teardown(async() => {
         await client.stop()
       })
-
-      const command1 = 'command1'
-      const sagaId1 = 'sagaId1'
-      const command2 = 'command2'
-      const sagaId2 = 'sagaId2'
-      const payload = { msg: 'a new command has been issued' }
-
-      const messages = [
-        {
-          key: sagaId1,
-          value: JSON.stringify({
-            messageLabel: command1,
-            messagePayload: payload,
-          }),
-          partition: 0,
-        }, {
-          key: sagaId2,
-          value: JSON.stringify({
-            messageLabel: command2,
-            messagePayload: payload,
-          }),
-          partition: 1,
-        },
-      ]
 
       let start1, end1, start2, end2
       const executor1 = async() => {

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -289,12 +289,12 @@ tap.test('Flow Manager Client', async t => {
       let start1, end1, start2, end2
       const executor1 = async() => {
         start1 = Date.now()
-        await sleep(2000)
+        await sleep(500)
         end1 = Date.now()
       }
       const executor2 = async() => {
         start2 = Date.now()
-        await sleep(2000)
+        await sleep(500)
         end2 = Date.now()
       }
 
@@ -317,11 +317,10 @@ tap.test('Flow Manager Client', async t => {
       const secondExecutedStart = start1 < start2 ? start2 : start1
       const sequentialCondition = firsExecutedEnd < secondExecutedStart
       assert.ok(sequentialCondition, 'Both commands have been executed sequentially')
-
       assert.end()
     })
 
-    t.test('execute commands in 2 partition concurrently if partitionsConsumedConcurrently is 2', async assert => {
+    t.only('execute commands in 2 partition concurrently if partitionsConsumedConcurrently is 2', async assert => {
       const client = new FlowManagerClient(
         log,
         {
@@ -344,12 +343,12 @@ tap.test('Flow Manager Client', async t => {
       let start1, end1, start2, end2
       const executor1 = async() => {
         start1 = Date.now()
-        await sleep(2000)
+        await sleep(500)
         end1 = Date.now()
       }
       const executor2 = async() => {
         start2 = Date.now()
-        await sleep(2000)
+        await sleep(500)
         end2 = Date.now()
       }
 

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -28,7 +28,7 @@ const getConfig = require('./getConfig')
 
 const FlowManagerClient = require('../lib/client')
 
-tap.test('Flow Manager Client', async t => {
+tap.only('Flow Manager Client', async t => {
   const conf = getConfig()
   const {
     kafkaInstance,
@@ -236,6 +236,9 @@ tap.test('Flow Manager Client', async t => {
     const commandIssuer = await kafkaCommon.createProducer(kafkaInstance)
     await setCmdTopicPartitions(2)
 
+    // let kafka reassign partitions to the consumer
+    await sleep(1000)
+
     const log = pino({ level: conf.LOG_LEVEL || 'silent' })
 
     t.teardown(async() => {
@@ -320,7 +323,7 @@ tap.test('Flow Manager Client', async t => {
       assert.end()
     })
 
-    t.only('execute commands in 2 partition concurrently if partitionsConsumedConcurrently is 2', async assert => {
+    t.test('execute commands in 2 partition concurrently if partitionsConsumedConcurrently is 2', async assert => {
       const client = new FlowManagerClient(
         log,
         {

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -28,7 +28,7 @@ const getConfig = require('./getConfig')
 
 const FlowManagerClient = require('../lib/client')
 
-tap.only('Flow Manager Client', async t => {
+tap.test('Flow Manager Client', async t => {
   const conf = getConfig()
   const {
     kafkaInstance,

--- a/tests/kafkaTestsHelpers.js
+++ b/tests/kafkaTestsHelpers.js
@@ -68,6 +68,16 @@ async function initializeKafkaClient(config) {
         // ignore errors in test
       }
     },
+    setCmdTopicPartitions: async(count) => {
+      await admin.createPartitions({
+        topicPartitions: [
+          {
+            topic: KAFKA_CMD_TOPIC,
+            count,
+          },
+        ],
+      })
+    },
   }
 }
 


### PR DESCRIPTION
Added the possibility to customize the `partitionsConsumedConcurrently` option of the consumer executor (the default value is `1`).

By doing so, you can create _n_ partition to be assigned to the same consumer, and by setting the `partitionsConsumedConcurrently` to _n_, you have the commands received in different partitions processed concurrently, grating increasing the performance if the commands involve asynchronous work.

This is based on the idea that messages in a partition must be processed in order, but since the saga runs in the same partition, different saga in different partition can be processed in parallel without worries.

Reference can be found in the official doc, section [partition-aware concurrency](https://kafka.js.org/docs/consuming#partition-aware-concurrency)

#### Checklist

- [x] your branch will not cause merge conflict with `master`
- [x] run `npm test`
- [x] tests are included
- [x] the documentation is updated or integrated accordingly with your changes
- [x] the code will follow the lint rules and style of the project
- [x] you are not committing extraneous files or sensible data
