### PR TITLE
fix(): Command executor type can be a promise too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix command executor type. Now it can also return a promise, making it async
+
 ## [1.0.4] 2022-10-26
 
 ### Changed

--- a/index.d.ts
+++ b/index.d.ts
@@ -70,11 +70,11 @@ export type EventEmitter = (event: string, metadata?: Record<string, any>) => Pr
 
 export type Heartbeat = () => Promise<void>
 
-export type CommandExecutor<Payload extends PayloadGeneric = PayloadGeneric> = (sagaId: string, payload: Payload, eventEmitter: EventEmitter, heartbeat: Heartbeat) => void
+export type CommandExecutor<Payload extends PayloadGeneric = PayloadGeneric> = (sagaId: string, payload: Payload, eventEmitter: EventEmitter, heartbeat: Heartbeat) => Promise<void> | void
 
 export type CommitCallback = () => Promise<void>
 
-export type CommandErrorHandler = (sagaId: string, error: Error, commitCallback: CommitCallback) => void
+export type CommandErrorHandler = (sagaId: string, error: Error, commitCallback: CommitCallback) => Promise<void> | void
 
 export interface FlowManagerClient {
   log: Record<string, any>


### PR DESCRIPTION
The command executor and error handler used to return only `void`. With this PR they will return `Promise<void> | void` making them async and awaitable

#### Checklist

- [X] your branch will not cause merge conflict with `master`
- [X] run `npm test`
- [X] tests are included
- [X] the documentation is updated or integrated accordingly with your changes
- [X] the code will follow the lint rules and style of the project
- [X] you are not committing extraneous files or sensible data
